### PR TITLE
fixed 'BytesBuffer has no length' for haxe 3.0.1

### DIFF
--- a/format/csv/Tools.hx
+++ b/format/csv/Tools.hx
@@ -145,19 +145,19 @@ class Tools {
 	// other tools ------------------------------------------------------------------------------------------------------
 
 	public static inline function getBufContents( b:BytesBuffer, utf8:Bool, ?pos=0, ?len=-1 ):String {
-		if ( len == -1 ) len = b.length - pos;
+		var bytes = b.getBytes();
+		if ( len == -1 ) len = bytes.length - pos;
 		#if ( neko || cpp )
-		return len > 0 ? b.getBytes().readString( pos, len ) : "";
+		return len > 0 ? bytes.readString( pos, len ) : "";
 		#else
 		if ( len == 0 ) {
 			return "";
 		}
 		else if ( utf8 ) {
-			return len > 0 ? b.getBytes().readString( pos, len ) : "";
+			return len > 0 ? bytes.readString( pos, len ) : "";
 		}
 		else {
 			var sbuf = new StringBuf();
-			var bytes = b.getBytes();
 			for ( i in pos...(pos+len) ) {
 				sbuf.addChar( bytes.get( i ) );
 			}

--- a/format/ett/Reader.hx
+++ b/format/ett/Reader.hx
@@ -165,8 +165,9 @@ class ETTReader {
 				i++;
 			}
 			if ( i == kb.length ) {
-				var bufLen = buf.length;
-				return buf.getBytes().sub( 0, bufLen - kb.length );
+				var bytes = buf.getBytes();
+				var bufLen = bytes.length;
+				return bytes.sub( 0, bufLen - kb.length );
 			}
 		}
 		return null;


### PR DESCRIPTION
Tests failed when i used haxelib install elebeta-format 1,0,0

```
################################################################################
###   UNIT TESTS - Neko (local)                                              ###
################################################################################
haxe  unit_tests.neko.hxml
format/csv/Tools.hx:148: characters 25-33 : haxe.io.BytesBuffer has no field length
format/ett/Reader.hx:168: characters 17-27 : haxe.io.BytesBuffer has no field length
make: *** [neko] Error 1
```

so i updated format.csv.Tools getBufContents() and 
format.ett.Reader readUntil()
and tests pass with this update.
